### PR TITLE
feat(CvTabsNavigation): create component and initial styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,79 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	font-family: var(--font-family);
+	font-size: var(--font-size-base);
+	color: var(--text-color);
+	margin: 0;
+	padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ul,
+ol,
+li,
+figure,
+figcaption,
+blockquote,
+dl,
+dd {
+	margin: 0;
+	padding: 0;
+}
+
+ul {
+	list-style-type: none;
+}
+
+a {
+	color: inherit;
+	text-decoration: none;
+}
+
+:root {
+	--bg-color: #ffffff;
+	--section-bg: #f9f9f9;
+	--line-color: #e0e0e0;
+	--color-hover: rgb(214, 214, 214);
+
+	--text-color: #222222;
+	--text-secondary: #555555;
+	--text-light: #888888;
+
+	--accent-color: #0073e6;
+	--accent-hover: #005bb5;
+
+	--font-family: "Helvetica", "Arial", sans-serif;
+	--font-size-base: 16px;
+	--font-size-small: 14px;
+	--font-size-large: 20px;
+	--font-size-title: 24px;
+
+	--spacing-xs: 4px;
+	--spacing-sm: 8px;
+	--spacing-md: 16px;
+	--spacing-lg: 24px;
+	--spacing-xl: 32px;
+
+	--container-width: 95%;
+	--border-radius: 4px;
+
+	--box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.app-container {
+	width: var(--container-width);
+	margin: 0 auto;
+	box-shadow: var(--box-shadow);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,7 @@
+import { useState } from "react";
 import "./App.css";
+import { CvTabsNavigation } from "./components/CvTabsNavigation/CvTabsNavigation";
+import { TABS } from "./components/CvTabsNavigation/Tabs";
 
 const cvData = {
 	personalInfo: {
@@ -75,10 +78,16 @@ Sports enthusiast, especially fitness and football.`,
 };
 
 function App() {
+	const [activeTab, setActiveTab] = useState(TABS.SIMPLE);
+
 	return (
-		<>
+		<div className="app-container">
+			<CvTabsNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
 			<h1>My CV online</h1>
-		</>
+
+			{activeTab === TABS.SIMPLE}
+			{activeTab === TABS.INTERACTIVE}
+		</div>
 	);
 }
 

--- a/src/components/CvTabsNavigation/CvTabsNavigation.jsx
+++ b/src/components/CvTabsNavigation/CvTabsNavigation.jsx
@@ -1,0 +1,19 @@
+import "./CvTbasNavigation.css";
+import { TABS } from "./Tabs";
+
+export const CvTabsNavigation = ({ activeTab, setActiveTab }) => {
+	return (
+		<nav className="nav-tabs">
+			{Object.entries(TABS).map(([property, value]) => (
+				<button
+					key={property}
+					className={`tab ${activeTab === value ? "active" : ""}`}
+					onClick={() => setActiveTab(value)}
+					data-tab={value.toLowerCase()}
+				>
+					{value}
+				</button>
+			))}
+		</nav>
+	);
+};

--- a/src/components/CvTabsNavigation/CvTbasNavigation.css
+++ b/src/components/CvTabsNavigation/CvTbasNavigation.css
@@ -1,0 +1,18 @@
+.tab {
+	background-color: var(--bg-color);
+	border: 1px solid var(--line-color);
+	border-bottom: none;
+	padding: var(--spacing-sm);
+	box-shadow: var(--box-shadow);
+	margin-top: var(--spacing-xs);
+	border-top-left-radius: var(--border-radius);
+	border-top-right-radius: var(--border-radius);
+}
+
+.tab[data-tab="interactive"] {
+	border-right: none;
+}
+
+.tab:hover {
+	background-color: var(--color-hover);
+}

--- a/src/components/CvTabsNavigation/Tabs.js
+++ b/src/components/CvTabsNavigation/Tabs.js
@@ -1,0 +1,4 @@
+export const TABS = {
+	SIMPLE: "Simple",
+	INTERACTIVE: "Interactive",
+};


### PR DESCRIPTION
## 🚀 Feature: CvTabsNavigation Component

### ✅ Summary

This PR introduces the `CvTabsNavigation` component, which adds basic tab-switching functionality for toggling between different CV views (e.g., Simple and Interactive). It also includes global style enhancements via `App.css`.

### 🔧 Changes Made

- Created `CvTabsNavigation` component with dynamic rendering based on tab state.
- Integrated the component in `App.jsx` using React `useState`.
- Applied conditional CSS classes to highlight the active tab.
- Added base layout styles in `App.css` including:
  - Global  via `:root` and `body`
  - Container width, spacing variables, and color tokens

### 📁 Files Affected

- `src/components/CvTabsNavigation/CvTabsNavigation.jsx`
- `src/components/CvTabsNavigation/CvTabsNavigation.css`
- `src/components/CvTabsNavigation/Tabs.js`
- `src/App.jsx`
- `src/App.css`

### 🧪 How to Test

1. Run the app: `npm run dev`
2. Confirm that the tabs appear at the top of the screen.
3. Clicking each tab should update the internal state (`activeTab`) and apply correct styling.

### 📌 Notes

- The visual content for the "Simple" and "Interactive" views will be implemented in a future PR.
- Uses semantic and accessible markup for better maintainability.

---

> Merging into `develop` as part of the CV builder feature stream.

