### PR TITLE
feat(Header): create header component with summary toggle functionality on differents Tabs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,7 +58,7 @@ a {
 	--font-size-base: 16px;
 	--font-size-small: 14px;
 	--font-size-large: 20px;
-	--font-size-title: 24px;
+	--font-size-title: 28px;
 
 	--spacing-xs: 4px;
 	--spacing-sm: 8px;

--- a/src/App.css
+++ b/src/App.css
@@ -56,6 +56,7 @@ a {
 
 	--font-family: "Helvetica", "Arial", sans-serif;
 	--font-size-base: 16px;
+	--font-size-xsmall: 10px;
 	--font-size-small: 14px;
 	--font-size-large: 20px;
 	--font-size-title: 28px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 import "./App.css";
 import { CvTabsNavigation } from "./components/CvTabsNavigation/CvTabsNavigation";
 import { TABS } from "./components/CvTabsNavigation/Tabs";
+import { Header } from "./components/Header/Header";
 
 const cvData = {
 	personalInfo: {
 		fullName: "Fernando Herrero Núñez",
-		title: "Junior Frontend Stack Developer",
+		title: "Junior Frontend Developer",
 		location: "Madrid, Spain",
 		email: "herrerofernando@gmail.com",
 		phone: "636325089",
@@ -83,10 +84,9 @@ function App() {
 	return (
 		<div className="app-container">
 			<CvTabsNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
-			<h1>My CV online</h1>
 
-			{activeTab === TABS.SIMPLE}
-			{activeTab === TABS.INTERACTIVE}
+			{activeTab === TABS.SIMPLE && <Header personalInfo={cvData.personalInfo} summary={cvData.summary} />}
+			{activeTab === TABS.INTERACTIVE && <Header personalInfo={cvData.personalInfo} summary={cvData.summary} />}
 		</div>
 	);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,9 +84,7 @@ function App() {
 	return (
 		<div className="app-container">
 			<CvTabsNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
-
-			{activeTab === TABS.SIMPLE && <Header personalInfo={cvData.personalInfo} summary={cvData.summary} />}
-			{activeTab === TABS.INTERACTIVE && <Header personalInfo={cvData.personalInfo} summary={cvData.summary} />}
+			<Header activeTab={activeTab} personalInfo={cvData.personalInfo} summary={cvData.summary} />
 		</div>
 	);
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,0 +1,53 @@
+.header-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing-md);
+	padding-top: var(--spacing-xl);
+}
+
+.header-name {
+	font-size: var(--font-size-title);
+}
+
+.header-content {
+	display: grid;
+	justify-items: center;
+	grid-template-columns: repeat(2, 1fr);
+	gap: var(--spacing-xs);
+	font-size: var(--font-size-small);
+	border-bottom: 1px solid var(--text-color);
+	padding-bottom: var(--spacing-md);
+}
+
+.header-content a {
+	color: var(--accent-color);
+	position: relative;
+	text-decoration: none;
+}
+
+.header-content a:hover {
+	color: var(--accent-hover);
+}
+
+.header-content a::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	bottom: -2px;
+	width: 0%;
+	height: 1px;
+	background-color: var(--accent-color);
+	transition: width 0.3s ease;
+}
+
+.header-content a:hover::after {
+	width: 100%;
+	color: var(--accent-hover);
+}
+
+.header-summary {
+    text-align: center;
+    font-size: var(--font-size-small);
+    line-height: var(--spacing-lg);
+}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -2,8 +2,19 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: var(--spacing-md);
 	padding-top: var(--spacing-xl);
+}
+
+.header-name-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing-md);
+	background-color: var(--section-bg);
+	border-radius: var(--border-radius);
+	padding-top: var(--spacing-md);
+	padding-bottom: var(--spacing-md);
+	border-bottom: 1px solid var(--text-color);
 }
 
 .header-name {
@@ -16,8 +27,6 @@
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--spacing-xs);
 	font-size: var(--font-size-small);
-	border-bottom: 1px solid var(--text-color);
-	padding-bottom: var(--spacing-md);
 }
 
 .header-content a {
@@ -47,7 +56,25 @@
 }
 
 .header-summary {
-    text-align: center;
-    font-size: var(--font-size-small);
-    line-height: var(--spacing-lg);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+}
+
+.summary-text {
+	text-align: center;
+	font-size: var(--font-size-small);
+	line-height: var(--spacing-lg);
+	background-color: var(--section-bg);
+	border-radius: var(--border-radius);
+	padding: var(--spacing-xs);
+}
+
+.summary-btn {
+	align-self: flex-end;
+	background-color: var(--bg-color);
+	border: none;
+	font-style: italic;
+	font-size: var(--font-size-xsmall);
+	color: var(--text-light);
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -27,6 +27,7 @@
 	grid-template-columns: repeat(2, 1fr);
 	gap: var(--spacing-xs);
 	font-size: var(--font-size-small);
+	padding: var(--spacing-xs);
 }
 
 .header-content a {
@@ -77,4 +78,5 @@
 	font-style: italic;
 	font-size: var(--font-size-xsmall);
 	color: var(--text-light);
+	cursor: pointer;
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,0 +1,26 @@
+import "./Header.css";
+
+export const Header = ({ personalInfo, summary }) => {
+	const { fullName, title, location, email, phone, linkedin, github } = personalInfo;
+
+	return (
+		<section className="header-container">
+			<h1 className="header-name">{fullName}</h1>
+
+			<div className="header-content">
+				<p>{title}</p>
+				<p>{location}</p>
+				<a href={`mailto:${email}`}>{email}</a>
+				<a href={`tel:${phone}`}>+{phone}</a>
+				<a href={linkedin} target="_blank">
+					Linkedin
+				</a>
+				<a href={github} target="_blank">
+					Github
+				</a>
+			</div>
+
+			<p className="header-summary">{summary}</p>
+		</section>
+	);
+};

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,26 +1,41 @@
+import { useState } from "react";
 import "./Header.css";
 
 export const Header = ({ personalInfo, summary }) => {
 	const { fullName, title, location, email, phone, linkedin, github } = personalInfo;
+	const [hideSummary, setHideSummary] = useState(false);
+
+	const onClickSummary = () => {
+		setHideSummary((prev) => !prev);
+	};
 
 	return (
 		<section className="header-container">
-			<h1 className="header-name">{fullName}</h1>
+			<div className="header-name-content">
+				<h1 className="header-name">{fullName}</h1>
 
-			<div className="header-content">
-				<p>{title}</p>
-				<p>{location}</p>
-				<a href={`mailto:${email}`}>{email}</a>
-				<a href={`tel:${phone}`}>+{phone}</a>
-				<a href={linkedin} target="_blank">
-					Linkedin
-				</a>
-				<a href={github} target="_blank">
-					Github
-				</a>
+				<div className="header-content">
+					<p>{title}</p>
+					<p>{location}</p>
+					<a href={`mailto:${email}`}>{email}</a>
+					<a href={`tel:${phone}`}>+{phone}</a>
+					<a href={linkedin} target="_blank">
+						Linkedin
+					</a>
+					<a href={github} target="_blank">
+						Github
+					</a>
+				</div>
 			</div>
 
-			<p className="header-summary">{summary}</p>
+			<button className="summary-btn" onClick={onClickSummary}>
+				{hideSummary ? "Show summary" : "Hide summary"}
+			</button>
+			{!hideSummary && (
+				<div className="header-summary">
+					<p className="summary-text">{summary}</p>
+				</div>
+			)}
 		</section>
 	);
 };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import "./Header.css";
 
-export const Header = ({ personalInfo, summary }) => {
+export const Header = ({ activeTab, personalInfo, summary }) => {
 	const { fullName, title, location, email, phone, linkedin, github } = personalInfo;
 	const [hideSummary, setHideSummary] = useState(false);
 
@@ -17,8 +17,8 @@ export const Header = ({ personalInfo, summary }) => {
 				<div className="header-content">
 					<p>{title}</p>
 					<p>{location}</p>
-					<a href={`mailto:${email}`}>{email}</a>
 					<a href={`tel:${phone}`}>+{phone}</a>
+					<a href={`mailto:${email}`}>{email}</a>
 					<a href={linkedin} target="_blank">
 						Linkedin
 					</a>
@@ -28,9 +28,11 @@ export const Header = ({ personalInfo, summary }) => {
 				</div>
 			</div>
 
-			<button className="summary-btn" onClick={onClickSummary}>
-				{hideSummary ? "Show summary" : "Hide summary"}
-			</button>
+			{activeTab === "Interactive" && (
+				<button className="summary-btn" onClick={onClickSummary}>
+					{hideSummary ? "Show summary" : "Hide summary"}
+				</button>
+			)}
 			{!hideSummary && (
 				<div className="header-summary">
 					<p className="summary-text">{summary}</p>


### PR DESCRIPTION
### ✨ Description

This Pull Request introduces the `Header` component for the CV application. Main changes include:

- ✅ Display of personal information: full name, title, location, contact details, and social links.
- 🔁 Functionality to show/hide the `summary` using a toggle button with `useState`.
- 🧠 The summary toggle button only appears when the active tab is `INTERACTIVE`, controlled via the `activeTab` prop.
- 💅 Styling added in `Header.css` to ensure a responsive and consistent layout.
- 🧼 Refactored `App.jsx` to avoid code duplication and pass down the `activeTab` prop to the `Header`.

### 📂 Modified Files

- `Header.jsx`
- `Header.css`
- `App.jsx`

### 📌 Notes

- This PR does **not** yet include the active tab styling for the navigation (`CvTabsNavigation`) — this will be added in a `fix` branch.
- Ready to be extended with more interactive features based on the selected tab.

---

✅ Ready for review.
