### PR TITLE
feat(ProfessionalExperience): create professional experience component functionality and styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -78,3 +78,16 @@ a {
 	margin: 0 auto;
 	box-shadow: var(--box-shadow);
 }
+
+h2 {
+	font-size: var(--font-size-large);
+	border-bottom: 1px solid var(--text-color);
+    width: 100%;
+}
+
+.section-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-top: var(--spacing-xl);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { CvTabsNavigation } from "./components/CvTabsNavigation/CvTabsNavigation";
 import { TABS } from "./components/CvTabsNavigation/Tabs";
 import { Header } from "./components/Header/Header";
+import { ProfessionalExperience } from "./components/ProfesionalExperience/ProfessionalExperience";
 
 const cvData = {
 	personalInfo: {
@@ -80,11 +81,27 @@ Sports enthusiast, especially fitness and football.`,
 
 function App() {
 	const [activeTab, setActiveTab] = useState(TABS.SIMPLE);
+	const [selectedItems, setSelectedItems] = useState({
+		experience: {},
+		education: {},
+		technicalSkills: {},
+		languages: {},
+	});
+
+	const toggleExperienceItems = (key) => {
+		setSelectedItems((prev) => ({ ...prev, experience: { ...prev.experience, [key]: !prev.experience[key] } }));
+	};
 
 	return (
 		<div className="app-container">
 			<CvTabsNavigation activeTab={activeTab} setActiveTab={setActiveTab} />
 			<Header activeTab={activeTab} personalInfo={cvData.personalInfo} summary={cvData.summary} />
+			<ProfessionalExperience
+				activeTab={activeTab}
+				experience={cvData.experience}
+				selectedItems={selectedItems}
+				toggleExperienceItems={toggleExperienceItems}
+			/>
 		</div>
 	);
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,14 +1,8 @@
-.header-container {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	padding-top: var(--spacing-xl);
-}
-
 .header-name-content {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	width: 100%;
 	gap: var(--spacing-md);
 	background-color: var(--section-bg);
 	border-radius: var(--border-radius);

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,7 +10,7 @@ export const Header = ({ activeTab, personalInfo, summary }) => {
 	};
 
 	return (
-		<section className="header-container">
+		<section className="section-container">
 			<div className="header-name-content">
 				<h1 className="header-name">{fullName}</h1>
 

--- a/src/components/ProfesionalExperience/ProfessionalExperience.css
+++ b/src/components/ProfesionalExperience/ProfessionalExperience.css
@@ -1,0 +1,17 @@
+.experience-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    padding-top: var(--spacing-md);
+    font-size: var(--font-size-small);
+}
+
+.experience-company-date {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.experience-responsabilities {
+    padding-left: var(--spacing-md);
+}

--- a/src/components/ProfesionalExperience/ProfessionalExperience.jsx
+++ b/src/components/ProfesionalExperience/ProfessionalExperience.jsx
@@ -1,0 +1,98 @@
+import "./ProfessionalExperience.css";
+
+export const ProfessionalExperience = ({ activeTab, experience, selectedItems, toggleExperienceItems }) => {
+	return (
+		<section className="section-container">
+			<h2>Professional Experience</h2>
+			{experience.map(({ position, company, period, location, responsibilities }, index) => {
+				const baseKey = `${position}-${company}`;
+
+				return (
+					<div key={`${baseKey}-${index}`} className="experience-content">
+						<div className="experience-company-date">
+							<div className="experience-company">
+								{activeTab === "Interactive" ? (
+									<>
+										<label>
+											<input
+												type="checkbox"
+												checked={selectedItems?.experience?.[`${baseKey}-company`] || false}
+												onChange={() => toggleExperienceItems(`${baseKey}-company`)}
+											/>
+											<strong>{company}</strong>
+										</label>
+
+										<label>
+											<input
+												type="checkbox"
+												checked={selectedItems?.experience?.[`${baseKey}-position`] || false}
+												onChange={() => toggleExperienceItems(`${baseKey}-position`)}
+											/>
+											{position}
+										</label>
+									</>
+								) : (
+									<>
+										<p>
+											<strong>{company}</strong>
+										</p>
+										<p>{position}</p>
+									</>
+								)}
+							</div>
+							<div className="experience-date">
+								{activeTab === "Interactive" ? (
+									<>
+										<label>
+											<input
+												type="checkbox"
+												checked={selectedItems?.experience?.[`${baseKey}-location`] || false}
+												onChange={() => toggleExperienceItems(`${baseKey}-location`)}
+											/>
+											{location}
+										</label>
+
+										<label>
+											<input
+												type="checkbox"
+												checked={selectedItems?.experience?.[`${baseKey}-period`] || false}
+												onChange={() => toggleExperienceItems(`${baseKey}-period`)}
+											/>
+											{period}
+										</label>
+									</>
+								) : (
+									<>
+										<p>
+											<strong>{location}</strong>
+										</p>
+										<p>{period}</p>
+									</>
+								)}
+							</div>
+						</div>
+
+						<div className="experience-responsabilities">
+							{responsibilities.map((responsability, i) => {
+								const key = `${baseKey}-responsability-${i}`;
+
+								return activeTab === "Interactive" ? (
+									<label key={key}>
+										<input
+											type="checkbox"
+											checked={selectedItems?.experience?.[key] || false}
+											onChange={() => toggleExperienceItems(key)}
+										/>
+										{responsability}
+									</label>
+								) : (
+									<li key={key}>{responsability}</li>
+								);
+							})}
+						</div>
+					</div>
+				);
+			})}
+		</section>
+	);
+};


### PR DESCRIPTION
# 🚀 Pull Request to `develop`: feat(ProfessionalExperience) from 'feature/professional-experience'

## ✨ Summary
This PR adds the complete logic and styling for the `ProfessionalExperience` component, including interactive functionality for selecting CV elements.

## 📌 What’s Included
- New `ProfessionalExperience` component with:
  - Interactive mode: allows users to select/deselect company, position, location, period, and individual responsibilities.
  - Static (simple) mode: displays experience content without interactivity.
- State management via `selectedItems.experience` in `App.jsx`.
- Unique key structure (`baseKey`) for consistent checkbox state mapping.
- Toggle logic through `toggleExperienceItems`.

## ✅ How to Test
1. Switch between tabs: `Simple` and `Interactive`.
2. In **Interactive mode**, check/uncheck different elements under each job.
3. Ensure selections persist correctly in the UI and are reflected in state.

## 🧠 Next Steps
- Extend selection logic to other sections (Education, Skills, Languages).
- Display summary view of selected items.
- Prepare for export functionality (PDF/download/etc.).

---

> Merging this into `develop` will complete the first milestone of the interactive CV builder.
