### PR TITLE
Refactor ShowModal component, fix responsibilities typo, and modularize Experience/Education items

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>CV-Fernando Herrero</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,6 +111,7 @@ function App() {
 				newSection[key] = value;
 			}
 
+			console.log("New section state:", newSection);
 			return { ...prev, [section]: newSection };
 		});
 	};
@@ -127,6 +128,7 @@ function App() {
 					itemsMap[id] = item;
 				}
 			}
+			console.log("New itemsMap state:", itemsMap);
 			return { ...prev, [section]: itemsMap };
 		});
 	};

--- a/src/components/EducationItemResume/EducationItemResume.jsx
+++ b/src/components/EducationItemResume/EducationItemResume.jsx
@@ -1,0 +1,19 @@
+export const EducationItemResume = ({ data, valuesSelection }) => {
+	const { institution, degree, location, period } = data;
+	const hasAnySelected =
+		valuesSelection.includes(institution) ||
+		valuesSelection.includes(degree) ||
+		valuesSelection.includes(location) ||
+		valuesSelection.includes(period);
+
+	if (!hasAnySelected) return null;
+
+	return (
+		<div>
+			{valuesSelection.includes(institution) && <p>{institution}</p>}
+			{valuesSelection.includes(degree) && <p>{degree}</p>}
+			{valuesSelection.includes(location) && <p>{location}</p>}
+			{valuesSelection.includes(period) && <p>{period}</p>}
+		</div>
+	);
+};

--- a/src/components/ExperienceItemResume/ExperienceItemResume.jsx
+++ b/src/components/ExperienceItemResume/ExperienceItemResume.jsx
@@ -1,0 +1,31 @@
+export const ExperienceItemResume = ({ data, valuesSelection }) => {
+	const { company, position, location, period, responsibilities } = data;
+	const normalizedValues = valuesSelection.map((v) => v.trim().toLowerCase());
+
+	const hasAnySelected =
+		normalizedValues.includes(company?.trim().toLowerCase() || "") ||
+		normalizedValues.includes(position?.trim().toLowerCase() || "") ||
+		normalizedValues.includes(location?.trim().toLowerCase() || "") ||
+		normalizedValues.includes(period?.trim().toLowerCase() || "") ||
+		responsibilities.some((responsability) =>
+			normalizedValues.includes(responsability?.trim().toLowerCase() || "")
+		);
+
+	if (!hasAnySelected) return null;
+
+	return (
+		<div>
+			{normalizedValues.includes(company?.trim().toLowerCase() || "") && <p>{company}</p>}
+			{normalizedValues.includes(position?.trim().toLowerCase() || "") && <p>{position}</p>}
+			{normalizedValues.includes(location?.trim().toLowerCase() || "") && <p>{location}</p>}
+			{normalizedValues.includes(period?.trim().toLowerCase() || "") && <p>{period}</p>}
+			<ul>
+				{responsibilities?.map((responsability, i) =>
+					normalizedValues.includes(responsability?.trim().toLowerCase() || "") ? (
+						<li key={i}>{responsability}</li>
+					) : null
+				)}
+			</ul>
+		</div>
+	);
+};

--- a/src/components/ProfesionalExperience/ProfessionalExperience.css
+++ b/src/components/ProfesionalExperience/ProfessionalExperience.css
@@ -16,7 +16,7 @@
 	gap: var(--spacing-xs);
 }
 
-.experience-responsabilities {
+.experience-responsibilities {
 	padding-left: var(--spacing-md);
 }
 
@@ -40,17 +40,17 @@
 	align-items: center;
 }
 
-.experience-responsabilities.interactive-mode {
+.experience-responsibilities.interactive-mode {
 	display: flex;
 	flex-direction: column;
 	padding-left: var(--spacing-xs);
 }
 
-.experience-responsabilities.interactive-mode label {
+.experience-responsibilities.interactive-mode label {
 	display: flex;
 	align-items: center;
 }
 
-.experience-responsabilities li {
+.experience-responsibilities li {
 	padding-bottom: var(--spacing-xs);
 }

--- a/src/components/ProfesionalExperience/ProfessionalExperience.jsx
+++ b/src/components/ProfesionalExperience/ProfessionalExperience.jsx
@@ -58,9 +58,9 @@ export const ProfessionalExperience = ({ activeTab, experience, selectedItems, t
 		);
 	};
 
-	const renderResponsabilities = (isInteractive, id, responsabilities) => {
+	const renderResponsibilities = (isInteractive, id, responsibilities) => {
 		if (isInteractive) {
-			return responsabilities.map((responsability, i) => {
+			return responsibilities.map((responsability, i) => {
 				const key = `${id}-${i}`;
 
 				return (
@@ -76,7 +76,7 @@ export const ProfessionalExperience = ({ activeTab, experience, selectedItems, t
 		}
 		return (
 			<ul>
-				{responsabilities.map((responsability, i) => {
+				{responsibilities.map((responsability, i) => {
 					const key = `${id}-${i}`;
 					return <li key={key}>{responsability}</li>;
 				})}
@@ -101,8 +101,8 @@ export const ProfessionalExperience = ({ activeTab, experience, selectedItems, t
 							</div>
 						</div>
 
-						<div className={`experience-responsabilities ${isInteractive ? "interactive-mode" : ""}`}>
-							{renderResponsabilities(isInteractive, id, responsibilities)}
+						<div className={`experience-responsibilities ${isInteractive ? "interactive-mode" : ""}`}>
+							{renderResponsibilities(isInteractive, id, responsibilities)}
 						</div>
 					</div>
 				);

--- a/src/components/ShowModal/ShowModal.jsx
+++ b/src/components/ShowModal/ShowModal.jsx
@@ -1,3 +1,5 @@
+import { EducationItemResume } from "../EducationItemResume/EducationItemResume";
+import { ExperienceItemResume } from "../ExperienceItemResume/ExperienceItemResume";
 import { Header } from "../Header/Header";
 import { ResumeButton } from "../ResumeButton/ResumeButton";
 import "./ShowModal.css";
@@ -10,12 +12,17 @@ export const ShowModal = ({ showModal, setShowModal, selectedItems, activeTab, c
 	const renderSection = (section) => {
 		const sectionData = selectedItems[section];
 
-		if (!sectionData || Object.keys(sectionData).length === 0) return;
-		let title = "";
-		if (section === "experience") title = "Professional Experience";
-		if (section === "education") title = "Education";
-		if (section === "technicalSkills") title = "Skills";
-		if (section === "languages") title = "Languages";
+		if (!sectionData || Object.keys(sectionData).length === 0) return null;
+
+		const valuesSelection = Object.values(sectionData);
+
+		const titles = {
+			experience: "Professional Experience",
+			education: "Education",
+			technicalSkills: "Skills",
+			languages: "Languages",
+		};
+		const title = titles[section];
 
 		const isSkillsOrLanguages = section === "technicalSkills" || section === "languages";
 
@@ -23,24 +30,39 @@ export const ShowModal = ({ showModal, setShowModal, selectedItems, activeTab, c
 			<section className="resume-section">
 				<h2>{title}</h2>
 
-				<ul>
-					{Object.entries(sectionData).map(([key, value]) => {
-						if (isSkillsOrLanguages) {
+				{section === "experience" && (
+					<>
+						{cvData.experience.map((item) => (
+							<ExperienceItemResume key={item.id} data={item} valuesSelection={valuesSelection} />
+						))}
+					</>
+				)}
+
+				{section === "education" && (
+					<>
+						{cvData.education.map((item) => (
+							<EducationItemResume key={item.id} data={item} valuesSelection={valuesSelection} />
+						))}
+					</>
+				)}
+
+				{isSkillsOrLanguages && (
+					<div>
+						{Object.entries(sectionData).map(([key, value]) => {
 							if (section === "technicalSkills") {
-								return <li key={key}>{value.name}</li>;
+								return <p key={key}>{value.name}</p>;
 							}
 							if (section === "languages") {
 								return (
-									<li key={key}>
+									<p key={key}>
 										{value.name}({value.level})
-									</li>
+									</p>
 								);
 							}
-						} else {
-							return <li key={key}>{value}</li>;
-						}
-					})}
-				</ul>
+							return null;
+						})}
+					</div>
+				)}
 			</section>
 		);
 	};

--- a/src/components/Skills/Skills.jsx
+++ b/src/components/Skills/Skills.jsx
@@ -10,7 +10,7 @@ export const Skills = ({ activeTab, skills, selectedItems, toggleItemSelected })
 			<div className={`items-content ${isInteractive ? "interactive-mode" : ""}`}>
 				{isInteractive ? (
 					skills.map(({ name, id }) => {
-						const isSelected = id in selectedItems.technicalSkills;
+						const isSelected = selectedItems.technicalSkills && id in selectedItems.technicalSkills;
 
 						return (
 							<ButtonItem


### PR DESCRIPTION
## Description

This pull request includes the following improvements and fixes:

- Refactored the `ShowModal` component to improve readability, maintainability, and proper conditional rendering based on selected items.
- Fixed the typo in the `responsibilities` property (previously `responsabilities`) across components and data to ensure consistency and avoid bugs.
- Created modular components:  
  - `ExperienceItemResume` to handle individual experience entries  
  - `EducationItemResume` to handle individual education entries  
- Improved filtering logic in `ExperienceItemResume` to properly normalize and check selected values with trimming and case normalization.  
- Added robust handling for optional data fields to avoid runtime errors.   
- Updated the resume rendering logic to correctly display sections based on selected filters (`experience`, `education`, `technicalSkills`, `languages`).  
- Ensured that the modal properly hides sections with no selected items and shows a fallback message when nothing is selected.

These changes enhance the stability and user experience of the resume modal, and pave the way for easier feature additions and maintenance going forward.
