### PR TITLE
feature: add storage to every element nedded

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,9 +12,11 @@ import { Languages } from "./components/Languages/Languages";
 import { DarkTheme } from "./components/DarkTheme/DarkTheme";
 import { cvData } from "./cvData";
 import { useSelectedItems } from "./hooks/useSelectedItems.js";
+import { storage } from "./helpers/storage.js";
 
 export const App = () => {
-	const [activeTab, setActiveTab] = useState(TABS.TRADITIONAL);
+	const saveTab = storage.get("activeTab");
+	const [activeTab, setActiveTab] = useState(saveTab || TABS.TRADITIONAL);
 	const [showModal, setShowModal] = useState(false);
 	const { selectedItems, toggleItems } = useSelectedItems();
 

--- a/src/components/TabsNavigation/TabsNavigation.jsx
+++ b/src/components/TabsNavigation/TabsNavigation.jsx
@@ -2,6 +2,7 @@ import "./TabsNavigation.css";
 import { TABS } from "./Tabs";
 import { InteractiveIntro } from "../InterativeIntro/InteractiveIntro";
 import { useState } from "react";
+import { storage } from "../../helpers/storage";
 
 export const TabsNavigation = ({ activeTab, setActiveTab }) => {
 	const [showIntro, setShowIntro] = useState(true);
@@ -15,7 +16,10 @@ export const TabsNavigation = ({ activeTab, setActiveTab }) => {
 				<button
 					key={property}
 					className={`tab ${activeTab === value ? "active" : ""}`}
-					onClick={() => setActiveTab(value)}
+					onClick={() => {
+						storage.save("activeTab", value);
+						setActiveTab(value);
+					}}
 					data-tab={value.toLowerCase()}
 				>
 					{value}

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,0 +1,63 @@
+/**
+ * Recupera un valor del localStorage.
+ * @param {string} key Clave con la que se buscará en el localStorage.
+ * @returns {*} El valor parseado si existe, o null si no existe o hay error.
+ */
+const getDataFromStorage = (key) => {
+	if (!key || typeof key !== "string") return null;
+
+	try {
+		const data = localStorage.getItem(key);
+		return data ? JSON.parse(data) : null;
+	} catch (error) {
+		console.error(`Error al obtener datos de localStorage con la clave "${key}":`, error);
+		return null;
+	}
+};
+
+/**
+ * Guarda un valor en el localStorage.
+ * @param {string} key Clave con la que se guardará en el localStorage.
+ * @param {*} data Puede ser cualquier tipo serializable (objeto, array, etc.).
+ */
+const saveDataInStorage = (key, data) => {
+	if (!key || typeof key !== "string") return;
+
+	try {
+		localStorage.setItem(key, JSON.stringify(data));
+	} catch (error) {
+		console.error(`Error al guardar datos en localStorage con la clave "${key}":`, error);
+	}
+};
+
+/**
+ * Elimina un valor del localStorage.
+ * @param {string} key Clave que se desea eliminar del localStorage.
+ */
+const removeDataFromStorage = (key) => {
+	if (!key || typeof key !== "string") return;
+
+	try {
+		localStorage.removeItem(key);
+	} catch (error) {
+		console.error(`Error al eliminar datos de localStorage con la clave "${key}":`, error);
+	}
+};
+
+/**
+ * Limpia por completo el localStorage.
+ */
+const clearAllStorage = () => {
+	try {
+		localStorage.clear();
+	} catch (error) {
+		console.error("Error al limpiar todo el localStorage:", error);
+	}
+};
+
+export const storage = {
+	get: getDataFromStorage,
+	save: saveDataInStorage,
+	remove: removeDataFromStorage,
+	clear: clearAllStorage,
+};

--- a/src/hooks/useSelectedItems.js
+++ b/src/hooks/useSelectedItems.js
@@ -1,12 +1,16 @@
 import { useState } from "react";
+import { storage } from "../helpers/storage";
 
 export const useSelectedItems = () => {
-	const [selectedItems, setSelectedItems] = useState({
-		experience: {},
-		education: {},
-		technicalSkills: {},
-		languages: {},
-	});
+	const saveItems = storage.get("selectedItems");
+	const [selectedItems, setSelectedItems] = useState(
+		saveItems || {
+			experience: {},
+			education: {},
+			technicalSkills: {},
+			languages: {},
+		}
+	);
 	const toggleItems = (section, id) => {
 		setSelectedItems((prev) => {
 			const newSection = { ...prev[section] };
@@ -17,12 +21,11 @@ export const useSelectedItems = () => {
 				newSection[id] = true;
 			}
 
-			console.log("New selected state:", { ...prev, [section]: newSection });
+			const update = { ...prev, [section]: newSection };
 
-			return {
-				...prev,
-				[section]: newSection,
-			};
+			storage.save("selectedItems", update);
+
+			return update;
 		});
 	};
 


### PR DESCRIPTION
### Summary

This PR introduces a new `helpers` directory that contains a dedicated utility file: `storage.js`. This module handles `localStorage` operations (get, save, remove, and clear) in a clean, reusable, and safe way.

### Changes

- ➕ Created `helpers/storage.js` with documented utility functions:
  - `get(key)`
  - `save(key, value)`
  - `remove(key)`
  - `clear()`
- ♻️ Integrated the storage helper in the `useSelectedItems` hook to persist user-selected data across sessions (via `localStorage`).
- ✅ Verified that selected state for experience, education, skills, and languages is correctly stored and restored after reload.

### Motivation

Keeping track of selected CV items in memory only led to data loss on page refresh. By saving selections in localStorage, we ensure a better user experience and maintain state persistence.

---

Let me know if you want to add screenshots or specific commit links. ¿Seguimos con otro componente?
